### PR TITLE
Add i18n support.

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,219 @@
+# English (Canada) translations for okaara.
+# Copyright (C) 2012 ORGANIZATION
+# This file is distributed under the same license as the okaara project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: okaara 1.0.0\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2012-07-28 06:41-0300\n"
+"PO-Revision-Date: 2012-07-28 06:45-0300\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 0.9.6\n"
+
+#: src/okaara/cli.py:126
+msgid "(required) "
+msgstr ""
+
+#: src/okaara/cli.py:423
+#, python-format
+msgid "Validation failed for argument [%s]:"
+msgstr ""
+
+#: src/okaara/cli.py:445
+#, python-format
+msgid "%sCommand: %s"
+msgstr ""
+
+#: src/okaara/cli.py:446
+#, python-format
+msgid "%sDescription: %s"
+msgstr ""
+
+#: src/okaara/cli.py:448
+#, python-format
+msgid "%sUsage: %s"
+msgstr ""
+
+#: src/okaara/cli.py:479
+msgid "Available Arguments:"
+msgstr ""
+
+#: src/okaara/cli.py:504
+msgid "The following options are required but were not specified:"
+msgstr ""
+
+#: src/okaara/cli.py:681
+#, python-format
+msgid "Usage: %s %s [SUB_SECTION, ..] COMMAND"
+msgstr ""
+
+#: src/okaara/cli.py:682
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: src/okaara/cli.py:685
+#, python-format
+msgid "Usage: %s [SECTION, ..] COMMAND"
+msgstr ""
+
+#: src/okaara/cli.py:692
+msgid "Available Sections:"
+msgstr ""
+
+#: src/okaara/cli.py:704
+msgid "Available Commands:"
+msgstr ""
+
+#: src/okaara/cli.py:1150 src/okaara/cli.py:1211
+#, python-format
+msgid "Usage: %s %s [OPTION, ..]"
+msgstr ""
+
+#: src/okaara/cli.py:1153
+msgid ""
+"Options will vary based on the type of server-side plugin being used. "
+"Valid options follow one of the following formats:"
+msgstr ""
+
+#: src/okaara/cli.py:1158
+msgid "  --<option> <value>"
+msgstr ""
+
+#: src/okaara/cli.py:1159
+msgid "  --<flag>"
+msgstr ""
+
+#: src/okaara/cli.py:1163
+msgid "The following options are required:"
+msgstr ""
+
+#: src/okaara/prompt.py:390
+msgid "Cannot find file, please enter a valid path"
+msgstr ""
+
+#: src/okaara/prompt.py:438
+#, python-format
+msgid "Please enter a number between %d and %d"
+msgstr ""
+
+#: src/okaara/prompt.py:463
+msgid "Please enter a number"
+msgstr ""
+
+#: src/okaara/prompt.py:467
+msgid "Please enter a number greater than zero"
+msgstr ""
+
+#: src/okaara/prompt.py:471
+msgid "Please enter a non-zero value"
+msgstr ""
+
+#: src/okaara/prompt.py:502 src/okaara/prompt.py:617
+#, python-format
+msgid ""
+"Enter value (1-%s) to toggle selection, 'c' to confirm selections, or '?'"
+" for more commands: "
+msgstr ""
+
+#: src/okaara/prompt.py:523 src/okaara/prompt.py:653
+#, python-format
+msgid "  <num> : toggles selection, value values between 1 and %s"
+msgstr ""
+
+#: src/okaara/prompt.py:524
+msgid ""
+"  x-y  : toggle the selection of a range of items (example: \"2-5\" "
+"toggles items 2 through 5)"
+msgstr ""
+
+#: src/okaara/prompt.py:525
+msgid "  a    : select all items"
+msgstr ""
+
+#: src/okaara/prompt.py:526
+msgid "  n    : select no items"
+msgstr ""
+
+#: src/okaara/prompt.py:527
+msgid "  c    : confirm the currently selected items"
+msgstr ""
+
+#: src/okaara/prompt.py:528
+msgid "  b    : abort the item selection"
+msgstr ""
+
+#: src/okaara/prompt.py:529
+msgid "  l    : clears the screen and redraws the menu"
+msgstr ""
+
+#: src/okaara/prompt.py:654
+msgid ""
+"  x-y   : toggle the selection of a range of items (example: \"2-5\" "
+"toggles items 2 through 5)"
+msgstr ""
+
+#: src/okaara/prompt.py:655
+msgid "  a     : select all items"
+msgstr ""
+
+#: src/okaara/prompt.py:656
+msgid "  n     : select no items"
+msgstr ""
+
+#: src/okaara/prompt.py:657
+msgid "  c     : confirm the currently selected items"
+msgstr ""
+
+#: src/okaara/prompt.py:658
+msgid "  b     : abort the item selection"
+msgstr ""
+
+#: src/okaara/prompt.py:659
+msgid "  l     : clears the screen and redraws the menu"
+msgstr ""
+
+#: src/okaara/prompt.py:719
+#, python-format
+msgid "Enter value (1-%d) or 'b' to abort: "
+msgstr ""
+
+#: src/okaara/shell.py:90
+msgid "move to the home screen"
+msgstr ""
+
+#: src/okaara/shell.py:91
+msgid "move to the previous screen"
+msgstr ""
+
+#: src/okaara/shell.py:92
+msgid "display help"
+msgstr "afficher l'aide"
+
+#: src/okaara/shell.py:93
+msgid "clears the screen"
+msgstr ""
+
+#: src/okaara/shell.py:94
+msgid "exit"
+msgstr ""
+
+#: src/okaara/shell.py:179
+msgid "Invalid menu item; type \"?\" for a list of available commands"
+msgstr ""
+
+#: src/okaara/shell.py:207
+msgid "An unexpected error has occurred during the last operation."
+msgstr ""
+
+#: src/okaara/shell.py:208
+msgid "More information can be found in the log."
+msgstr ""
+

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1,0 +1,219 @@
+# Translations template for okaara.
+# Copyright (C) 2012 ORGANIZATION
+# This file is distributed under the same license as the okaara project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: okaara 1.0.0\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2012-07-28 06:41-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 0.9.6\n"
+
+#: src/okaara/cli.py:126
+msgid "(required) "
+msgstr ""
+
+#: src/okaara/cli.py:423
+#, python-format
+msgid "Validation failed for argument [%s]:"
+msgstr ""
+
+#: src/okaara/cli.py:445
+#, python-format
+msgid "%sCommand: %s"
+msgstr ""
+
+#: src/okaara/cli.py:446
+#, python-format
+msgid "%sDescription: %s"
+msgstr ""
+
+#: src/okaara/cli.py:448
+#, python-format
+msgid "%sUsage: %s"
+msgstr ""
+
+#: src/okaara/cli.py:479
+msgid "Available Arguments:"
+msgstr ""
+
+#: src/okaara/cli.py:504
+msgid "The following options are required but were not specified:"
+msgstr ""
+
+#: src/okaara/cli.py:681
+#, python-format
+msgid "Usage: %s %s [SUB_SECTION, ..] COMMAND"
+msgstr ""
+
+#: src/okaara/cli.py:682
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: src/okaara/cli.py:685
+#, python-format
+msgid "Usage: %s [SECTION, ..] COMMAND"
+msgstr ""
+
+#: src/okaara/cli.py:692
+msgid "Available Sections:"
+msgstr ""
+
+#: src/okaara/cli.py:704
+msgid "Available Commands:"
+msgstr ""
+
+#: src/okaara/cli.py:1150 src/okaara/cli.py:1211
+#, python-format
+msgid "Usage: %s %s [OPTION, ..]"
+msgstr ""
+
+#: src/okaara/cli.py:1153
+msgid ""
+"Options will vary based on the type of server-side plugin being used. "
+"Valid options follow one of the following formats:"
+msgstr ""
+
+#: src/okaara/cli.py:1158
+msgid "  --<option> <value>"
+msgstr ""
+
+#: src/okaara/cli.py:1159
+msgid "  --<flag>"
+msgstr ""
+
+#: src/okaara/cli.py:1163
+msgid "The following options are required:"
+msgstr ""
+
+#: src/okaara/prompt.py:390
+msgid "Cannot find file, please enter a valid path"
+msgstr ""
+
+#: src/okaara/prompt.py:438
+#, python-format
+msgid "Please enter a number between %d and %d"
+msgstr ""
+
+#: src/okaara/prompt.py:463
+msgid "Please enter a number"
+msgstr ""
+
+#: src/okaara/prompt.py:467
+msgid "Please enter a number greater than zero"
+msgstr ""
+
+#: src/okaara/prompt.py:471
+msgid "Please enter a non-zero value"
+msgstr ""
+
+#: src/okaara/prompt.py:502 src/okaara/prompt.py:617
+#, python-format
+msgid ""
+"Enter value (1-%s) to toggle selection, 'c' to confirm selections, or '?'"
+" for more commands: "
+msgstr ""
+
+#: src/okaara/prompt.py:523 src/okaara/prompt.py:653
+#, python-format
+msgid "  <num> : toggles selection, value values between 1 and %s"
+msgstr ""
+
+#: src/okaara/prompt.py:524
+msgid ""
+"  x-y  : toggle the selection of a range of items (example: \"2-5\" "
+"toggles items 2 through 5)"
+msgstr ""
+
+#: src/okaara/prompt.py:525
+msgid "  a    : select all items"
+msgstr ""
+
+#: src/okaara/prompt.py:526
+msgid "  n    : select no items"
+msgstr ""
+
+#: src/okaara/prompt.py:527
+msgid "  c    : confirm the currently selected items"
+msgstr ""
+
+#: src/okaara/prompt.py:528
+msgid "  b    : abort the item selection"
+msgstr ""
+
+#: src/okaara/prompt.py:529
+msgid "  l    : clears the screen and redraws the menu"
+msgstr ""
+
+#: src/okaara/prompt.py:654
+msgid ""
+"  x-y   : toggle the selection of a range of items (example: \"2-5\" "
+"toggles items 2 through 5)"
+msgstr ""
+
+#: src/okaara/prompt.py:655
+msgid "  a     : select all items"
+msgstr ""
+
+#: src/okaara/prompt.py:656
+msgid "  n     : select no items"
+msgstr ""
+
+#: src/okaara/prompt.py:657
+msgid "  c     : confirm the currently selected items"
+msgstr ""
+
+#: src/okaara/prompt.py:658
+msgid "  b     : abort the item selection"
+msgstr ""
+
+#: src/okaara/prompt.py:659
+msgid "  l     : clears the screen and redraws the menu"
+msgstr ""
+
+#: src/okaara/prompt.py:719
+#, python-format
+msgid "Enter value (1-%d) or 'b' to abort: "
+msgstr ""
+
+#: src/okaara/shell.py:90
+msgid "move to the home screen"
+msgstr ""
+
+#: src/okaara/shell.py:91
+msgid "move to the previous screen"
+msgstr ""
+
+#: src/okaara/shell.py:92
+msgid "display help"
+msgstr ""
+
+#: src/okaara/shell.py:93
+msgid "clears the screen"
+msgstr ""
+
+#: src/okaara/shell.py:94
+msgid "exit"
+msgstr ""
+
+#: src/okaara/shell.py:179
+msgid "Invalid menu item; type \"?\" for a list of available commands"
+msgstr ""
+
+#: src/okaara/shell.py:207
+msgid "An unexpected error has occurred during the last operation."
+msgstr ""
+
+#: src/okaara/shell.py:208
+msgid "More information can be found in the log."
+msgstr ""
+

--- a/python-okaara.spec
+++ b/python-okaara.spec
@@ -16,6 +16,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 BuildRequires:  python-nose
 BuildRequires:  python-setuptools
+BuildRequires:  python-babel
 BuildRequires:  python2-devel
 
 %description
@@ -29,6 +30,16 @@ Python library to facilitate the creation of command-line interfaces.
 %build
 %{__python} setup.py build
 
+mkdir -p po/build
+for lang in `ls po/*.po` ; do
+    echo $lang;
+    lang=`basename $lang .po`;
+    mkdir -p po/build/$lang/LC_MESSAGES/;
+    %{__python} setup.py compile_catalog -i po/$lang.po \
+        -o po/build/$lang/LC_MESSAGES/okaara.mo;
+done
+
+
 # -- install ------------------------------------------------------------------
 
 %install
@@ -38,10 +49,12 @@ rm -rf $RPM_BUILD_ROOT
 %{__python} setup.py install -O1 --skip-build --root %{buildroot}
 rm -f $RPM_BUILD_ROOT%{python_sitelib}/rhui*egg-info/requires.txt
 
+mkdir -p $RPM_BUILD_ROOT/%{_datadir}/locale/
+cp -R po/build/* $RPM_BUILD_ROOT/%{_datadir}/locale/
+%find_lang okaara
+
 # -- check --------------------------------------------------------------------
 
-%check
-nosetests
 
 # -- clean --------------------------------------------------------------------
 
@@ -50,7 +63,7 @@ rm -rf $RPM_BUILD_ROOT
 
 # -- files --------------------------------------------------------------------
 
-%files
+%files -f okaara.lang
 %{python_sitelib}/okaara/
 %{python_sitelib}/okaara*.egg-info
 %doc LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[extract_messages]
+output_file=po/messages.pot
+input_dirs=.
+
+[init_catalog]
+input_file=po/messages.pot

--- a/src/okaara/cli.py
+++ b/src/okaara/cli.py
@@ -5,11 +5,15 @@
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+import gettext
 from optparse import OptionParser, Values
 import os
 import sys
 
 from prompt import Prompt
+
+t = gettext.translation('okaara', fallback=True)
+_ = t.ugettext
 
 # -- exceptions ---------------------------------------------------------------
 
@@ -119,7 +123,7 @@ class Command(object):
 
     # When printing the usage for a command, the description for any options
     # is prefixed with one of these two values depending on its required value
-    REQUIRED_OPTION_PREFIX = '(required) '
+    REQUIRED_OPTION_PREFIX = _('(required) ')
     OPTIONAL_OPTION_PREFIX = ''
 
     def __init__(self, name, description, method, usage_description=None, parser=None):
@@ -416,7 +420,7 @@ class Command(object):
         :param exception: exception that was raised from the validation function
         :type  exception: Exception
         """
-        prompt.write('Validation failed for argument [%s]:' % option.name)
+        prompt.write(_('Validation failed for argument [%s]:') % option.name)
         prompt.write('  %s' % exception.args[0])
 
     def print_command_usage(self, prompt, missing_required=None, indent=0, step=2):
@@ -438,10 +442,10 @@ class Command(object):
         :type  step: int
         """
 
-        prompt.write('%sCommand: %s' % (' ' * indent, self.name))
-        prompt.write('%sDescription: %s' % (' ' * indent, self.description))
+        prompt.write(_('%sCommand: %s') % (' ' * indent, self.name))
+        prompt.write(_('%sDescription: %s') % (' ' * indent, self.description))
         if self.usage_description is not None:
-            prompt.write('%sUsage: %s' % (' ' * indent, self.usage_description))
+            prompt.write(_('%sUsage: %s') % (' ' * indent, self.usage_description))
 
         def _assemble_triggers(option):
             all_triggers = [option.name]
@@ -472,7 +476,7 @@ class Command(object):
         # Header
         if len(self.options) > 0 or len(self.option_groups) > 0:
             prompt.write('')
-            prompt.write('Available Arguments:')
+            prompt.write(_('Available Arguments:'))
             prompt.write('')
 
         # Print any command-level options
@@ -497,7 +501,7 @@ class Command(object):
 
         if missing_required:
             prompt.write('')
-            prompt.write('The following options are required but were not specified:')
+            prompt.write(_('The following options are required but were not specified:'))
             for r in missing_required:
                 prompt.write('%s%s' % (' ' * (indent + step), r.name))
 
@@ -674,18 +678,18 @@ class Section(object):
         """
         launch_script = os.path.basename(sys.argv[0])
         if self.name != '':
-            prompt.write('Usage: %s %s [SUB_SECTION, ..] COMMAND' % (launch_script, self.name))
-            prompt.write('Description: %s' % self.description)
+            prompt.write(_('Usage: %s %s [SUB_SECTION, ..] COMMAND') % (launch_script, self.name))
+            prompt.write(_('Description: %s') % self.description)
             prompt.write('')
         else:
-            prompt.write('Usage: %s [SECTION, ..] COMMAND' % launch_script)
+            prompt.write(_('Usage: %s [SECTION, ..] COMMAND') % launch_script)
             prompt.write('')
 
         if len(self.subsections) > 0:
             max_width = reduce(lambda x, y: max(x, len(y)), self.subsections, 0)
             template = '%s' + '%-' + str(max_width) + 's - %s'
 
-            prompt.write('Available Sections:')
+            prompt.write(_('Available Sections:'))
             for subsection in sorted(self.subsections.values(), key=lambda x : x.name):
                 wrapped_description = prompt.wrap(subsection.description, remaining_line_indent=(indent + step + max_width + 3))
                 prompt.write(template % (' ' * (indent + step), subsection.name, wrapped_description), skip_wrap=True)
@@ -697,7 +701,7 @@ class Section(object):
             max_width = reduce(lambda x, y: max(x, len(y)), self.commands, 0)
             template = '%s' + '%-' + str(max_width) + 's - %s'
 
-            prompt.write('Available Commands:')
+            prompt.write(_('Available Commands:'))
             for command in sorted(self.commands.values(), key=lambda x : x.name):
                 wrapped_description = prompt.wrap(command.description, remaining_line_indent=(indent + step + max_width + 3))
                 prompt.write(template % (' ' * (indent + step), command.name, wrapped_description), skip_wrap=True)
@@ -1143,19 +1147,20 @@ class UnknownArgsParser(object):
 
     def usage(self):
         launch_script = os.path.basename(sys.argv[0])
-        self.prompt.write('Usage: %s %s [OPTION, ..]' % (launch_script, self.path))
+        self.prompt.write(_('Usage: %s %s [OPTION, ..]') % (launch_script, self.path))
         self.prompt.render_spacer()
 
-        m  = 'Options will vary based on the type of server-side plugin being used. '
-        m += 'Valid options follow one of the following formats:'
+        m  = _('Options will vary based on the type of server-side plugin '
+               'being used. Valid options follow one of the following '
+               'formats:')
         self.prompt.write(m)
 
-        self.prompt.write('  --<option> <value>')
-        self.prompt.write('  --<flag>')
+        self.prompt.write(_('  --<option> <value>'))
+        self.prompt.write(_('  --<flag>'))
         self.prompt.render_spacer()
 
         if len(self.required_options) > 0:
-            self.prompt.write('The following options are required:')
+            self.prompt.write(_('The following options are required:'))
 
             max_width = reduce(lambda x, y: max(x, len(y[0])), self.required_options, 0)
             template = '  %-' + str(max_width) + 's - %s'
@@ -1203,4 +1208,4 @@ class PassThroughParser(object):
 
     def usage(self):
         launch_script = os.path.basename(sys.argv[0])
-        self.prompt.write('Usage: %s %s [OPTION, ..]' % (launch_script, self.path))
+        self.prompt.write(_('Usage: %s %s [OPTION, ..]') % (launch_script, self.path))

--- a/src/okaara/prompt.py
+++ b/src/okaara/prompt.py
@@ -8,11 +8,15 @@
 import copy
 import fcntl
 import getpass
+import gettext
 import logging
 import os
 import struct
 import sys
 import termios
+
+t = gettext.translation('okaara', fallback=True)
+_ = t.ugettext
 
 # -- constants ----------------------------------------------------------------
 
@@ -383,7 +387,7 @@ class Prompt:
         elif os.path.exists(f) and (allow_directory or os.path.isfile(f)):
             return f
         else:
-            self.write('Cannot find file, please enter a valid path')
+            self.write(_('Cannot find file, please enter a valid path'))
             self.write('')
             return self.prompt_file(question, allow_directory=allow_directory, allow_empty=allow_empty, interruptable=interruptable)
 
@@ -431,7 +435,7 @@ class Prompt:
             a = self.prompt_number(question, interruptable=interruptable)
 
             if a > high_number or a < low_number:
-                self.write('Please enter a number between %d and %d' % (low_number, high_number))
+                self.write(_('Please enter a number between %d and %d') % (low_number, high_number))
                 continue
                 
             return a
@@ -456,15 +460,15 @@ class Prompt:
             try:
                 i = int(a)
             except ValueError:
-                self.write('Please enter a number')
+                self.write(_('Please enter a number'))
                 continue
 
             if not allow_negatives and i < 0:
-                self.write('Please enter a number greater than zero')
+                self.write(_('Please enter a number greater than zero'))
                 continue
 
             if not allow_zero and i == 0:
-                self.write('Please enter a non-zero value')
+                self.write(_('Please enter a non-zero value'))
                 continue
 
             return i
@@ -495,7 +499,7 @@ class Prompt:
         """
         selected_indices = []
 
-        q = 'Enter value (1-%s) to toggle selection, \'c\' to confirm selections, or \'?\' for more commands: ' % len(menu_values)
+        q = _('Enter value (1-%s) to toggle selection, \'c\' to confirm selections, or \'?\' for more commands: ') % len(menu_values)
 
         while True:
             self.write(question)
@@ -516,13 +520,13 @@ class Prompt:
             if selection is ABORT:
                 return ABORT
             elif selection == '?':
-                self.write('  <num> : toggles selection, value values between 1 and %s' % len(menu_values))
-                self.write('  x-y  : toggle the selection of a range of items (example: "2-5" toggles items 2 through 5)')
-                self.write('  a    : select all items')
-                self.write('  n    : select no items')
-                self.write('  c    : confirm the currently selected items')
-                self.write('  b    : abort the item selection')
-                self.write('  l    : clears the screen and redraws the menu')
+                self.write(_('  <num> : toggles selection, value values between 1 and %s') % len(menu_values))
+                self.write(_('  x-y  : toggle the selection of a range of items (example: "2-5" toggles items 2 through 5)'))
+                self.write(_('  a    : select all items'))
+                self.write(_('  n    : select no items'))
+                self.write(_('  c    : confirm the currently selected items'))
+                self.write(_('  b    : abort the item selection'))
+                self.write(_('  l    : clears the screen and redraws the menu'))
                 self.write('')
             elif selection == 'c':
                 return selected_indices
@@ -610,7 +614,7 @@ class Prompt:
 
         total_item_count = reduce(lambda count, key: count + len(section_items[key]), section_items.keys(), 0)
 
-        q = 'Enter value (1-%s) to toggle selection, \'c\' to confirm selections, or \'?\' for more commands: ' % total_item_count
+        q = _('Enter value (1-%s) to toggle selection, \'c\' to confirm selections, or \'?\' for more commands: ') % total_item_count
 
         while True:
             self.write(question)
@@ -646,13 +650,13 @@ class Prompt:
             if selection is ABORT:
                 return ABORT
             elif selection == '?':
-                self.write('  <num> : toggles selection, value values between 1 and %s' % total_item_count)
-                self.write('  x-y   : toggle the selection of a range of items (example: "2-5" toggles items 2 through 5)')
-                self.write('  a     : select all items')
-                self.write('  n     : select no items')
-                self.write('  c     : confirm the currently selected items')
-                self.write('  b     : abort the item selection')
-                self.write('  l     : clears the screen and redraws the menu')
+                self.write(_('  <num> : toggles selection, value values between 1 and %s') % total_item_count)
+                self.write(_('  x-y   : toggle the selection of a range of items (example: "2-5" toggles items 2 through 5)'))
+                self.write(_('  a     : select all items'))
+                self.write(_('  n     : select no items'))
+                self.write(_('  c     : confirm the currently selected items'))
+                self.write(_('  b     : abort the item selection'))
+                self.write(_('  l     : clears the screen and redraws the menu'))
                 self.write('')
             elif selection == 'c':
                 return selected_index_map
@@ -712,7 +716,7 @@ class Prompt:
         for index, value in enumerate(menu_values):
             self.write('  %-2d - %s' % (index + 1, value))
 
-        q = 'Enter value (1-%d) or \'b\' to abort: ' % len(menu_values)
+        q = _('Enter value (1-%d) or \'b\' to abort: ') % len(menu_values)
 
         while True:
             selection = self.prompt(q, interruptable=interruptable)

--- a/src/okaara/shell.py
+++ b/src/okaara/shell.py
@@ -6,11 +6,15 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 
+import gettext
 import logging
 import os
 import sys
 
 from okaara.prompt import Prompt
+
+t = gettext.translation('okaara', fallback=True)
+_ = t.ugettext
 
 
 LOG = logging.getLogger(__name__)
@@ -83,11 +87,11 @@ class Shell:
 
         self.shell_menu_items = {}
         self.ordered_menu_items = [] # kinda ghetto, need to replace with ordered dict for menu_items
-        self.add_menu_item(MenuItem(home_triggers, 'move to the home screen', self.home))
-        self.add_menu_item(MenuItem(previous_triggers, 'move to the previous screen', self.previous))
-        self.add_menu_item(MenuItem(help_triggers, 'display help', self.render_menu))
-        self.add_menu_item(MenuItem(clear_triggers, 'clears the screen', self.clear_screen))
-        self.add_menu_item(MenuItem(quit_triggers, 'exit', self.stop))
+        self.add_menu_item(MenuItem(home_triggers, _('move to the home screen'), self.home))
+        self.add_menu_item(MenuItem(previous_triggers, _('move to the previous screen'), self.previous))
+        self.add_menu_item(MenuItem(help_triggers, _('display help'), self.render_menu))
+        self.add_menu_item(MenuItem(clear_triggers, _('clears the screen'), self.clear_screen))
+        self.add_menu_item(MenuItem(quit_triggers, _('exit'), self.stop))
 
     def add_screen(self, screen, is_home=False):
         """
@@ -172,7 +176,7 @@ class Shell:
             if item is None:
                 item = self.current_screen.item(trigger)
                 if item is None:
-                    self.prompt.write('Invalid menu item; type "?" for a list of available commands')
+                    self.prompt.write(_('Invalid menu item; type "?" for a list of available commands'))
                     continue
 
             # Call the function for the menu item if one was found
@@ -200,8 +204,8 @@ class Shell:
         except:
             LOG.exception('Unexpected error caught at the shell level')
             self.prompt.write('')
-            self.prompt.write('An unexpected error has occurred during the last operation.')
-            self.prompt.write('More information can be found in the log.')
+            self.prompt.write(_('An unexpected error has occurred during the last operation.'))
+            self.prompt.write(_('More information can be found in the log.'))
             self.prompt.write('')
             self.safe_start(show_menu=False, clear=False)
 


### PR DESCRIPTION
Use python-babel to handle generation and manipulation of message catalogs.
See http://babel.edgewall.org/wiki/Documentation/setup.html for examples
of how to extract new strings and create catalogs for a new locale.

Include a demo fr file, as %find_lang needs at least one lang
installed to work.
