### PR TITLE
Improved Python 3 compatibility.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -182,8 +182,7 @@ htmlhelp_basename = 'Okaaradoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Okaara.tex', u'Okaara Documentation',
-   u'Jay Dobies', 'manual'),
+    ('index', 'Okaara.tex', u'Okaara Documentation', u'Jay Dobies', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/okaara/parsers.py
+++ b/okaara/parsers.py
@@ -154,7 +154,7 @@ def parse_csv_string(value):
     if value is None:
         raise ValueError(_('value is required'))
 
-    return csv_module.reader((value,)).next()
+    return next(csv_module.reader((value,)))
 
 
 def parse_optional_csv_string(value):

--- a/okaara/progress.py
+++ b/okaara/progress.py
@@ -19,6 +19,10 @@ take a Prompt as the output writer. The caller is responsible the iteration
 and will call the appropriate method in each object to make it display the
 current state.
 """
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 
 import math
 import threading
@@ -27,7 +31,7 @@ import time
 import okaara.prompt
 
 
-class ProgressBar:
+class ProgressBar(object):
 
     def __init__(self, prompt, width=40, show_trailing_percentage=True, fill='=', left_tick='[',
                  right_tick=']', in_progress_color=None, completed_color=None, render_tag=None):
@@ -185,7 +189,7 @@ class ProgressBar:
             self.prompt.clear(okaara.prompt.CLEAR_REMAINDER)
 
 
-class Spinner:
+class Spinner(object):
 
     DEFAULT_SEQUENCE = '- \ | /'.split()
 
@@ -283,7 +287,7 @@ class Spinner:
 
         for item in iterable:
             yield item
-            self.next()
+            next(self)
 
     def clear(self):
         """
@@ -383,7 +387,7 @@ class ThreadedSpinner(Spinner):
         self._thread_running = True
 
         while self.running:
-            self.next()
+            next(self)
             time.sleep(self.refresh_seconds)
             self.ellapsed_time += self.refresh_seconds
 

--- a/okaara/prompt.py
+++ b/okaara/prompt.py
@@ -12,7 +12,11 @@
 #
 # You should have received a copy of the GNU General Public License along with Okaara.
 # If not, see <http://www.gnu.org/licenses/>.
+from __future__ import division
+from builtins import str
+from builtins import object
 
+from functools import reduce
 import copy
 import fcntl
 import getpass
@@ -24,7 +28,10 @@ import sys
 import termios
 
 t = gettext.translation('okaara', fallback=True)
-_ = t.ugettext
+if sys.version_info[0] < 3:
+    _ = t.ugettext
+else:
+    _ = t.gettext
 
 # -- constants ----------------------------------------------------------------
 
@@ -81,7 +88,7 @@ TAG_WRITE = 'write'
 
 # -- classes ------------------------------------------------------------------
 
-class Prompt:
+class Prompt(object):
     """
     Used to communicate between the application and the user. The Prompt class can be
     subclassed to provide custom implementations of read and write to alter the input/output
@@ -147,7 +154,7 @@ class Prompt:
         try:
             r = self.input.readline().rstrip() # rstrip removes the trailing \n
             return r
-        except (EOFError, KeyboardInterrupt), e:
+        except (EOFError, KeyboardInterrupt) as e:
             if interruptable:
                 self.write('') # the ^C won't cause a line break but we probably want one
                 return ABORT
@@ -230,7 +237,7 @@ class Prompt:
         if len(text) >= width:
             return text
         else:
-            spacer = ' ' * ( (width - len(text)) / 2)
+            spacer = ' ' * ((width - len(text)) // 2)
             return spacer + text
 
     def wrap(self, content, wrap_width=None, remaining_line_indent=0):
@@ -431,7 +438,7 @@ class Prompt:
 
         if a is ABORT:
             return a
-            
+
         return a.lower() == 'y'
 
     def prompt_range(self, question, high_number, low_number=1, interruptable=True):
@@ -445,7 +452,7 @@ class Prompt:
             if a > high_number or a < low_number:
                 self.write(_('Please enter a number between %d and %d') % (low_number, high_number))
                 continue
-                
+
             return a
 
     def prompt_number(self, question, allow_negatives=False, allow_zero=False, default_value=None, interruptable=True):
@@ -539,7 +546,7 @@ class Prompt:
             elif selection == 'c':
                 return selected_indices
             elif selection == 'a':
-                selected_indices = range(0, len(menu_values))
+                selected_indices = list(range(0, len(menu_values)))
             elif selection == 'n':
                 selected_indices = []
             elif selection == 'b':
@@ -620,7 +627,7 @@ class Prompt:
         for key in section_items:
             selected_index_map[key] = []
 
-        total_item_count = reduce(lambda count, key: count + len(section_items[key]), section_items.keys(), 0)
+        total_item_count = reduce(lambda count, key: count + len(section_items[key]), list(section_items.keys()), 0)
 
         q = _('Enter value (1-%s) to toggle selection, \'c\' to confirm selections, or \'?\' for more commands: ') % total_item_count
 
@@ -672,7 +679,7 @@ class Prompt:
                 # Recreate the selected index map, adding in indices for each item
                 selected_index_map = {}
                 for key in section_items:
-                    selected_index_map[key] = range(0, len(section_items[key]))
+                    selected_index_map[key] = list(range(0, len(section_items[key])))
             elif selection == 'n':
                 selected_index_map = {}
                 for key in section_items:
@@ -874,8 +881,8 @@ class Prompt:
         upper = parsed[1].strip()
 
         return lower.isdigit() and int(lower) > 0 and \
-               upper.isdigit() and int(upper) <= selectable_item_count and \
-               int(lower) < int(upper)
+            upper.isdigit() and int(upper) <= selectable_item_count and \
+            int(lower) < int(upper)
 
     def _range(self, input):
         """
@@ -909,7 +916,7 @@ class Prompt:
 
         self.tags.append(t)
 
-class Recorder:
+class Recorder(object):
     """
     Suitable for passing to the Prompt constructor as the output, an instance
     of this class will store every line written to it in an internal list.
@@ -921,7 +928,7 @@ class Recorder:
     def write(self, line):
         self.lines.append(line)
 
-class Script:
+class Script(object):
     """
     Suitable for passing to the Prompt constructor as the input, an instance
     of this class will return each line set within on each call to read.

--- a/okaara/shell.py
+++ b/okaara/shell.py
@@ -12,6 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License along with Okaara.
 # If not, see <http://www.gnu.org/licenses/>.
+from builtins import object
 
 import gettext
 import logging
@@ -21,7 +22,10 @@ import sys
 from okaara.prompt import Prompt
 
 t = gettext.translation('okaara', fallback=True)
-_ = t.ugettext
+if sys.version_info[0] < 3:
+    _ = t.ugettext
+else:
+    _ = t.gettext
 
 
 LOG = logging.getLogger(__name__)
@@ -33,7 +37,7 @@ class Exit(Exception):
     pass
 
 
-class Shell:
+class Shell(object):
     """
     Represents a single shell interface. A shell constists of one or more screens
     that drive the different sections of the shell. At any given time, only one
@@ -84,7 +88,7 @@ class Shell:
 
         if include_long_triggers:
             home_triggers.append('home')
-            
+
             quit_triggers.append('quit')
             quit_triggers.append('exit')
 
@@ -256,10 +260,10 @@ class Shell:
 
         if clear:
             self.clear_screen()
-                    
+
         self.previous_screen = self.current_screen
         self.current_screen = self.screens[to_screen_id]
-        
+
         if show_menu:
             self.render_menu(display_shell_menu=False)
 
@@ -307,7 +311,7 @@ class Shell:
                 self.prompt.write('')
                 for item in self.ordered_menu_items:
                     self._render_menu_item(', '.join(item.triggers), item.description)
-            
+
         self.prompt.write('')
 
     def _render_menu_item(self, trigger, description):
@@ -328,7 +332,7 @@ class Shell:
         return p
 
 
-class Screen:
+class Screen(object):
     """
     A screen is an individual "section" of a shell. The granularity of its use will
     vary based on the application but can most easily be related to different
@@ -401,7 +405,7 @@ def noop():
     """
     pass
 
-class MenuItem:
+class MenuItem(object):
     """
     An individual menu item the user can interact with. The shell instance will
     take care of determining which menu item the user has selected and invoking
@@ -444,7 +448,7 @@ class MenuItem:
         # Make sure it's in list form
         if not isinstance(triggers, list) and not isinstance(triggers, tuple):
             triggers = [triggers]
-        
+
         self.triggers = triggers
         self.description = description
         self.func = func

--- a/okaara/table.py
+++ b/okaara/table.py
@@ -12,7 +12,11 @@
 #
 # You should have received a copy of the GNU General Public License along with Okaara.
 # If not, see <http://www.gnu.org/licenses/>.
+from __future__ import division
+from builtins import range
+from builtins import object
 
+from functools import reduce
 import copy
 
 # -- constants ----------------------------------------------------------------
@@ -178,7 +182,7 @@ class Table(object):
                     elif alignment == ALIGN_RIGHT:
                         text = padding + text
                     else:
-                        left_padding_count = (width - len(text)) / 2
+                        left_padding_count = (width - len(text)) // 2
                         right_padding_count = (width - len(text)) - left_padding_count
 
                         left_padding = ' ' * left_padding_count
@@ -231,8 +235,8 @@ class Table(object):
         # If not specified, evenly divide across the table width and throw
         # out any extra space
         if col_widths is None:
-            minus_separators = table_width - ( (self.num_cols - 1) * len(self.col_separator) )
-            each_col_width = minus_separators / self.num_cols
+            minus_separators = table_width - ((self.num_cols - 1) * len(self.col_separator))
+            each_col_width = minus_separators // self.num_cols
             col_widths = [each_col_width for i in range(0, self.num_cols)]
 
         # If the table width is greater than the total width of the columns,

--- a/samples/sample_cli.py
+++ b/samples/sample_cli.py
@@ -43,7 +43,7 @@ class SampleSectionOne(Section):
 
     def optional_args(self, **kwargs):
         self.prompt.write('Supplied Arguments:')
-        for k, v in kwargs.items():
+        for k, v in kwargs:
             self.prompt.write('Key: %-10s   Value: %s' % (k, v))
 
 

--- a/samples/sample_progress.py
+++ b/samples/sample_progress.py
@@ -72,7 +72,7 @@ def spinner_demo():
 
     total = 10
     for i in range(0, total):
-        spinner.next()
+        next(spinner)
         time.sleep(.25)
 
     spinner.clear()
@@ -128,7 +128,6 @@ def threaded_spinner_demo():
 
     p.write('Threaded spinner stopped')
     p.write('')
-
 
     s = ThreadedSpinner(p, refresh_seconds=3)
 

--- a/setup.py
+++ b/setup.py
@@ -10,23 +10,19 @@
 from setuptools import setup, find_packages
 
 setup(
-        name='okaara',
-        version='1.0.35',
-        description='Python command line utilities',
-        url='https://okaara.readthedocs.org/en/latest/',
-        license='GPLv2',
-
-        author='Jay Dobies',
-        author_email='jdobies@gmail.com',
-
-        packages = find_packages(),
-
-        test_suite = 'nose.collector',
-
-        classifiers = [
-            'License :: OSI Approved :: GNU General Public License (GPL)',
-            'Intended Audience :: Developers',
-            'Intended Audience :: Information Technology',
-            'Programming Language :: Python'
-        ],
+    name='okaara',
+    version='1.0.35',
+    description='Python command line utilities',
+    url='https://okaara.readthedocs.org/en/latest/',
+    license='GPLv2',
+    author='Jay Dobies',
+    author_email='jdobies@gmail.com',
+    packages=find_packages(),
+    test_suite='nose.collector',
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License (GPL)',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Programming Language :: Python'
+    ],
 )

--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -69,7 +69,7 @@ class ExtensionsManagerTests(unittest.TestCase):
         # Test
         try:
             manager.load()
-        except extensions.LoadFailed, e:
+        except extensions.LoadFailed as e:
             self.assertEqual(1, len(e.failed_descriptors))
             self.assertEqual('sample-bad', e.failed_descriptors[0].name)
 


### PR DESCRIPTION
Hello.

I am providing changes which improve Python 3 compatibility. All tests pass in both versions of Python.

**Python 2**
```
$ python --version
Python 2.7.12
$ python setup.py test
running test
running egg_info
writing okaara.egg-info/PKG-INFO
writing top-level names to okaara.egg-info/top_level.txt
writing dependency_links to okaara.egg-info/dependency_links.txt
reading manifest file 'okaara.egg-info/SOURCES.txt'
writing manifest file 'okaara.egg-info/SOURCES.txt'
running build_ext
test_found_section_not_command (test_cli.FindClosestMatchTests) ... ok
test_good_section_bad_section_good_section (test_cli.FindClosestMatchTests) ... ok
test_no_match_at_all (test_cli.FindClosestMatchTests) ... ok
test_successful_find_command (test_cli.FindClosestMatchTests) ... ok
test_valid_extensions (test_extensions.DirectoryExtensionsLoader) ... ok
test_load (test_extensions.ExtensionsManagerTests) ... ok
test_load_with_error (test_extensions.ExtensionsManagerTests) ... ok
test_invalid (test_parsers.ParseBooleanTests) ... ok
test_optional (test_parsers.ParseBooleanTests) ... ok
test_optional_empty_string (test_parsers.ParseBooleanTests) ... ok
test_optional_invalid (test_parsers.ParseBooleanTests) ... ok
test_optional_valid (test_parsers.ParseBooleanTests) ... ok
test_required (test_parsers.ParseBooleanTests) ... ok
test_valid_false (test_parsers.ParseBooleanTests) ... ok
test_valid_true (test_parsers.ParseBooleanTests) ... ok
test_basic_values (test_parsers.ParseCSVTests) ... ok
test_optional (test_parsers.ParseCSVTests) ... ok
test_optional_empty_string (test_parsers.ParseCSVTests) ... ok
test_optional_value (test_parsers.ParseCSVTests) ... ok
test_required (test_parsers.ParseCSVTests) ... ok
test_single_value (test_parsers.ParseCSVTests) ... ok
test_invalid (test_parsers.ParseIntTests) ... ok
test_valid (test_parsers.ParseIntTests) ... ok
test_negative (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional_empty_string (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional_invalid (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional_valid (test_parsers.ParseNonNegativeIntTests) ... ok
test_string (test_parsers.ParseNonNegativeIntTests) ... ok
test_valid (test_parsers.ParseNonNegativeIntTests) ... ok
test_zero (test_parsers.ParseNonNegativeIntTests) ... ok
test_negative (test_parsers.ParsePostiveIntTests) ... ok
test_optional (test_parsers.ParsePostiveIntTests) ... ok
test_optional_empty_string (test_parsers.ParsePostiveIntTests) ... ok
test_optional_invalid (test_parsers.ParsePostiveIntTests) ... ok
test_optional_valid (test_parsers.ParsePostiveIntTests) ... ok
test_string (test_parsers.ParsePostiveIntTests) ... ok
test_valid (test_parsers.ParsePostiveIntTests) ... ok
test_zero (test_parsers.ParsePostiveIntTests) ... ok
test_color (test_prompt.GeneralTests)
Tests the color call correctly wraps the text with the correct markers. ... ok
test_read_interrupt (test_prompt.GeneralTests)
Tests that having read catch interrupt correctly returns the abort code. ... ok
test_write_color (test_prompt.GeneralTests)
Tests the color functionality built into write works. ... ok
test_write_with_wrap (test_prompt.GeneralTests)
Tests using an auto-wrap value correctly wraps text. ... ok
test_prompt_allow_empty (test_prompt.PromptTest)
Tests that a prompt will accept empty and not error. ... ok
test_prompt_menu (test_prompt.PromptTest)
Basic tests for prompting a menu of items and selecting a valid one. ... ok
test_prompt_no_empty (test_prompt.PromptTest)
Tests that a prompt that does not allow empty values re-prompts the user ... ok
test_prompt_non_interruptable (test_prompt.PromptTest)
Tests that a non-interruptable prompt properly raises an exception if interrupted. ... ok
test_prompt_password (test_prompt.PromptTest)
Make sure this correctly passes through to getpass one way or another ... ok
test_get_password (test_prompt.TestGetPassword) ... ok
test_py24_behavior (test_prompt.TestGetPassword) ... ok
test_py26_behavior (test_prompt.TestGetPassword) ... ok
test_wrap_long_wrap (test_prompt.WrapTests)
Tests that chop correctly handles data shorter than the chop length. ... ok
test_wrap_short_wrap (test_prompt.WrapTests)
Tests that chop correctly handled data longer than the chop length. ... ok
test_wrap_smart_split (test_prompt.WrapTests)
Tests smart wrapping to not break words. ... ok
test_wrap_with_none (test_prompt.WrapTests)
Tests that chop with a None wrap width doesn't crash. ... ok
test_equal_table_and_cols_no_separator (test_table.TableTests) ... ok
test_equal_table_and_cols_with_separator (test_table.TableTests) ... ok
test_larger_col_widths (test_table.TableTests) ... ok
test_larger_table_width (test_table.TableTests) ... ok
test_table_width_no_col_widths (test_table.TableTests) ... ok
test_invalid (test_validators.PartialValidateRegexTests) ... ok
test_valid (test_validators.PartialValidateRegexTests) ... ok
test_invalid (test_validators.ValidateBooleanTests) ... ok
test_valid (test_validators.ValidateBooleanTests) ... ok
test_invalid (test_validators.ValidateIntTests) ... ok
test_valid (test_validators.ValidateIntTests) ... ok

----------------------------------------------------------------------
Ran 66 tests in 0.047s

OK
```

**Python 3**
```
$ python --version
Python 3.5.1
$ python setup.py test
running test
running egg_info
writing top-level names to okaara.egg-info/top_level.txt
writing okaara.egg-info/PKG-INFO
writing dependency_links to okaara.egg-info/dependency_links.txt
reading manifest file 'okaara.egg-info/SOURCES.txt'
writing manifest file 'okaara.egg-info/SOURCES.txt'
running build_ext
test_found_section_not_command (test_cli.FindClosestMatchTests) ... ok
test_good_section_bad_section_good_section (test_cli.FindClosestMatchTests) ... ok
test_no_match_at_all (test_cli.FindClosestMatchTests) ... ok
test_successful_find_command (test_cli.FindClosestMatchTests) ... ok
test_valid_extensions (test_extensions.DirectoryExtensionsLoader) ... ok
test_load (test_extensions.ExtensionsManagerTests) ... ok
test_load_with_error (test_extensions.ExtensionsManagerTests) ... ok
test_invalid (test_parsers.ParseBooleanTests) ... ok
test_optional (test_parsers.ParseBooleanTests) ... ok
test_optional_empty_string (test_parsers.ParseBooleanTests) ... ok
test_optional_invalid (test_parsers.ParseBooleanTests) ... ok
test_optional_valid (test_parsers.ParseBooleanTests) ... ok
test_required (test_parsers.ParseBooleanTests) ... ok
test_valid_false (test_parsers.ParseBooleanTests) ... ok
test_valid_true (test_parsers.ParseBooleanTests) ... ok
test_basic_values (test_parsers.ParseCSVTests) ... ok
test_optional (test_parsers.ParseCSVTests) ... ok
test_optional_empty_string (test_parsers.ParseCSVTests) ... ok
test_optional_value (test_parsers.ParseCSVTests) ... ok
test_required (test_parsers.ParseCSVTests) ... ok
test_single_value (test_parsers.ParseCSVTests) ... ok
test_invalid (test_parsers.ParseIntTests) ... ok
test_valid (test_parsers.ParseIntTests) ... ok
test_negative (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional_empty_string (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional_invalid (test_parsers.ParseNonNegativeIntTests) ... ok
test_optional_valid (test_parsers.ParseNonNegativeIntTests) ... ok
test_string (test_parsers.ParseNonNegativeIntTests) ... ok
test_valid (test_parsers.ParseNonNegativeIntTests) ... ok
test_zero (test_parsers.ParseNonNegativeIntTests) ... ok
test_negative (test_parsers.ParsePostiveIntTests) ... ok
test_optional (test_parsers.ParsePostiveIntTests) ... ok
test_optional_empty_string (test_parsers.ParsePostiveIntTests) ... ok
test_optional_invalid (test_parsers.ParsePostiveIntTests) ... ok
test_optional_valid (test_parsers.ParsePostiveIntTests) ... ok
test_string (test_parsers.ParsePostiveIntTests) ... ok
test_valid (test_parsers.ParsePostiveIntTests) ... ok
test_zero (test_parsers.ParsePostiveIntTests) ... ok
test_color (test_prompt.GeneralTests)
Tests the color call correctly wraps the text with the correct markers. ... ok
test_read_interrupt (test_prompt.GeneralTests)
Tests that having read catch interrupt correctly returns the abort code. ... ok
test_write_color (test_prompt.GeneralTests)
Tests the color functionality built into write works. ... ok
test_write_with_wrap (test_prompt.GeneralTests)
Tests using an auto-wrap value correctly wraps text. ... ok
test_prompt_allow_empty (test_prompt.PromptTest)
Tests that a prompt will accept empty and not error. ... ok
test_prompt_menu (test_prompt.PromptTest)
Basic tests for prompting a menu of items and selecting a valid one. ... ok
test_prompt_no_empty (test_prompt.PromptTest)
Tests that a prompt that does not allow empty values re-prompts the user ... ok
test_prompt_non_interruptable (test_prompt.PromptTest)
Tests that a non-interruptable prompt properly raises an exception if interrupted. ... ok
test_prompt_password (test_prompt.PromptTest)
Make sure this correctly passes through to getpass one way or another ... ok
test_get_password (test_prompt.TestGetPassword) ... ok
test_py24_behavior (test_prompt.TestGetPassword) ... ok
test_py26_behavior (test_prompt.TestGetPassword) ... ok
test_wrap_long_wrap (test_prompt.WrapTests)
Tests that chop correctly handles data shorter than the chop length. ... ok
test_wrap_short_wrap (test_prompt.WrapTests)
Tests that chop correctly handled data longer than the chop length. ... ok
test_wrap_smart_split (test_prompt.WrapTests)
Tests smart wrapping to not break words. ... ok
test_wrap_with_none (test_prompt.WrapTests)
Tests that chop with a None wrap width doesn't crash. ... ok
test_equal_table_and_cols_no_separator (test_table.TableTests) ... ok
test_equal_table_and_cols_with_separator (test_table.TableTests) ... ok
test_larger_col_widths (test_table.TableTests) ... ok
test_larger_table_width (test_table.TableTests) ... ok
test_table_width_no_col_widths (test_table.TableTests) ... ok
test_invalid (test_validators.PartialValidateRegexTests) ... ok
test_valid (test_validators.PartialValidateRegexTests) ... ok
test_invalid (test_validators.ValidateBooleanTests) ... ok
test_valid (test_validators.ValidateBooleanTests) ... ok
test_invalid (test_validators.ValidateIntTests) ... ok
test_valid (test_validators.ValidateIntTests) ... ok

----------------------------------------------------------------------
Ran 66 tests in 0.047s

OK
```

I have also prepared specfile for RPM but it would be better to test it with new release before we push it.

Could you please check and merge this PR and make a new release? 