### PR TITLE
Add python3-future dependency for the builtins imports

### DIFF
--- a/python-okaara.spec
+++ b/python-okaara.spec
@@ -3,7 +3,7 @@
 # -- headers ------------------------------------------------------------------
 
 Name:           python-okaara
-Version:        1.0.35
+Version:        1.0.37
 Release:        1%{?dist}
 Summary:        Python command line utilities
 
@@ -21,6 +21,7 @@ BuildRequires:  python2-devel
 BuildRequires:  python-mock
 
 Requires:       python-setuptools
+Requires:       python3-future
 
 %description
 Python library to facilitate the creation of command-line interfaces.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='okaara',
-    version='1.0.36',
+    version='1.0.37',
     description='Python command line utilities',
     url='https://okaara.readthedocs.org/en/latest/',
     license='GPLv2',
@@ -24,5 +24,8 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'Programming Language :: Python'
+    ],
+    install_requires=[
+        'future',
     ],
 )


### PR DESCRIPTION
Currently okaara breaks when bulitin is imported unless python-future is installed.